### PR TITLE
JSON-RPC 2.0 over stdio

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "autorest-rust"
+version = "0.1.0"
+authors = ["Cameron Taggart <cameron.taggart@gmail.com>"]
+edition = "2018"
+
+[dependencies]
+tokio = { version = "0.2", features = ["macros", "io-std", "io-util"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,4 +5,5 @@ authors = ["Cameron Taggart <cameron.taggart@gmail.com>"]
 edition = "2018"
 
 [dependencies]
-tokio = { version = "0.2", features = ["macros", "io-std", "io-util"] }
+# jsonrpc-core = "*"
+jsonrpc-core = { git = "https://github.com/paritytech/jsonrpc" }

--- a/main.js
+++ b/main.js
@@ -1,0 +1,15 @@
+"use strict";
+const fs = require("fs");
+const { WASI } = require("wasi");
+const wasi = new WASI({
+  args: process.argv,
+  env: process.env,
+});
+const importObject = { wasi_snapshot_preview1: wasi.wasiImport };
+(async () => {
+  const wasm = await WebAssembly.compile(
+    fs.readFileSync("target/wasm32-wasi/debug/autorest-rust.wasm")
+  );
+  const instance = await WebAssembly.instantiate(wasm, importObject);
+  wasi.start(instance);
+})();

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,2 @@
+merge_imports = true
+max_width = 140

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,0 +1,16 @@
+use tokio::io::{self, AsyncBufReadExt, BufReader};
+
+pub type Error = Box<dyn std::error::Error + Send + Sync>;
+pub type Result<T> = std::result::Result<T, Error>;
+
+#[tokio::main]
+pub async fn main() -> Result<()> {
+    let stdin = io::stdin();
+    let mut lines = BufReader::new(stdin).lines();
+
+    while let Some(line) = lines.next_line().await? {
+        println!("length = {}", line.len());
+    }
+
+    Ok(())
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,11 +1,17 @@
+use jsonrpc_core::{IoHandler, Params, Value};
 use std::{io, io::prelude::*};
 
 pub type Error = Box<dyn std::error::Error + Send + Sync>;
 pub type Result<T> = std::result::Result<T, Error>;
 
 pub fn main() -> Result<()> {
-    for line in io::stdin().lock().lines() {
-        println!("length = {}", line?.len());
+    let mut handler = IoHandler::new();
+    handler.add_sync_method("say_hello", |_: Params| Ok(Value::String("Hello World!".to_owned())));
+
+    for req in io::stdin().lock().lines() {
+        if let Some(rsp) = handler.handle_request_sync(&req?) {
+            println!("{}", rsp);
+        }
     }
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,16 +1,11 @@
-use tokio::io::{self, AsyncBufReadExt, BufReader};
+use std::{io, io::prelude::*};
 
 pub type Error = Box<dyn std::error::Error + Send + Sync>;
 pub type Result<T> = std::result::Result<T, Error>;
 
-#[tokio::main]
-pub async fn main() -> Result<()> {
-    let stdin = io::stdin();
-    let mut lines = BufReader::new(stdin).lines();
-
-    while let Some(line) = lines.next_line().await? {
-        println!("length = {}", line.len());
+pub fn main() -> Result<()> {
+    for line in io::stdin().lock().lines() {
+        println!("length = {}", line?.len());
     }
-
     Ok(())
 }


### PR DESCRIPTION
The extensions communicate over stdio, using JSON-RPC 2.0. This is how to do that using Rust. `cargo build --target=wasm32-wasi` works as well.

To test, run `cargo run` or `cargo wasi run` and 

Entering this request line:
``` json
{"jsonrpc": "2.0", "method": "say_hello", "id": 1}
```
Will respond with this line:
``` json
{"jsonrpc":"2.0","result":"Hello World!","id":1}
```

links
https://github.com/paritytech/jsonrpsee/issues/122
https://github.com/Azure/autorest/issues/3502#issuecomment-666581835